### PR TITLE
Replace Markdown table with a list

### DIFF
--- a/Organizer-Timeline/4-Months-Before/Sponsorship/Draft-Your-Budget.md
+++ b/Organizer-Timeline/4-Months-Before/Sponsorship/Draft-Your-Budget.md
@@ -10,12 +10,10 @@ Note: We recommend you build in a buffer of $1,000 to $3,000, depending on the s
 
 Over the years the we've found the averages costs for major budget items are as follows:
 
-| Item | Cost |
-|:-----|:-----|
-| Food | $7 per person per meal |
-| Snacks & Drinks | $10 per person |
-| T-Shirts | $5-8 per person (dependent on volume) |
-| Busses | $3,500 per bus |
+- **Food**: $7 per person per meal
+- **Snacks & Drinks**: $10 per person
+- **T-Shirts**: $5-8 per person (dependent on volume)
+- **Busses**: $3,500 per bus
 
 Resources:
 


### PR DESCRIPTION
The markdown tables don't render correctly when we use it in League emails. We need to use lists instead.